### PR TITLE
restricts err when column in Airtable & not in  schema

### DIFF
--- a/lib/airtable/airtable.js
+++ b/lib/airtable/airtable.js
@@ -48,9 +48,13 @@ const fromAirtableFormat = (record, table) => {
     const jsFormattedName = invertedColumns[origColumn];
 
     if (!jsFormattedName) {
-      throw new Error(
-        `Error converting ${table} record from Airtable. Could not find column of name "${origColumn}" in local copy of schema.js. Please run the schema generator again to get updates`
-      );
+      // throw new Error(
+      //   `Error converting ${table} record from Airtable. Could not find column of name "${origColumn}" in local copy of schema.js. Please run the schema generator again to get updates`
+      // );
+      return {
+        ...obj,
+        [origColumn]: record[origColumn],
+      };
     }
 
     let value = record[origColumn];

--- a/lib/airtable/airtable.js
+++ b/lib/airtable/airtable.js
@@ -48,9 +48,13 @@ const fromAirtableFormat = (record, table) => {
     const jsFormattedName = invertedColumns[origColumn];
 
     if (!jsFormattedName) {
+      // Adding new Columns to Airtable, should not throw Err/break code
+
       // throw new Error(
       //   `Error converting ${table} record from Airtable. Could not find column of name "${origColumn}" in local copy of schema.js. Please run the schema generator again to get updates`
       // );
+
+      // New Coulmns added to Airtbale are returned as part of the object, even when they dont match the local schema.
       return {
         ...obj,
         [origColumn]: record[origColumn],


### PR DESCRIPTION
- Removes "Throw err" when new Columns have been introduced in Airtable, but do not match the local schema.
- This prevents the PROD app from breaking when new columns have been introduced in Airtable.